### PR TITLE
fix: restore backend dependency wiring

### DIFF
--- a/backend/src/container.ts
+++ b/backend/src/container.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+import { ResultsRepository } from '@/repositories/results.repository';
+import { SurveyRepository } from '@/repositories/survey.repository';
+
+const prisma = new PrismaClient();
+
+export const container = {
+  prisma,
+  surveyRepository: new SurveyRepository(prisma),
+  resultsRepository: new ResultsRepository(prisma),
+};


### PR DESCRIPTION
## 📌 Summary
Restore backend dependency wiring so the current imports resolve cleanly.

## 🔧 Changes Made
- Added a minimal container for Prisma and repository instances
- Kept wiring centralized and small

## 🧠 Reason
- Fix broken imports
- Keep the app compiling
- Avoid introducing a larger DI pattern

