### PR TITLE
chore(frontend): remove unused noise

### DIFF
--- a/frontend/src/components/ui/TextField/index.ts
+++ b/frontend/src/components/ui/TextField/index.ts
@@ -1,1 +1,0 @@
-export { default as TextField } from './TextField';

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,3 +1,3 @@
 export { Loading } from './Loading/Loading';
 export { ErrorMessage, InlineError } from './ErrorMessage/ErrorMessage';
-export { TextField } from './TextField';
+export { default as TextField } from './TextField/TextField';

--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -14,7 +14,7 @@ const parseEnv = () => {
   }
 };
 
-export const env = parseEnv();
+const env = parseEnv();
 
 export const config = {
   apiUrl: env.VITE_API_URL,

--- a/frontend/src/config/queryClient.ts
+++ b/frontend/src/config/queryClient.ts
@@ -31,5 +31,3 @@ export const queryClient = new QueryClient({
     },
   },
 });
-
-export default queryClient;

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,1 +1,0 @@
-export { useResults } from './useQuery';

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,4 +1,3 @@
-// frontend/tsconfig.app.json
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
@@ -9,7 +8,6 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
@@ -17,14 +15,12 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
 
-    /* Path Aliases */
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],

--- a/frontend/tsconfig.eslint.json
+++ b/frontend/tsconfig.eslint.json
@@ -1,5 +1,0 @@
-// frontend/tsconfig.eslint.json
-{
-  "extends": "./tsconfig.app.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
-}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,4 +1,3 @@
-// frontend/tsconfig.json
 {
   "extends": "./tsconfig.app.json",
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,4 +1,3 @@
-// frontend/tsconfig.node.json
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
@@ -7,14 +6,12 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
 
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary

Removes unused frontend noise from exports and config files.

## Changes

- Removed unused frontend barrel files for `TextField` and hooks
- Pointed the UI barrel directly at `TextField.tsx`
- Made `env` internal to frontend config and removed the unused `queryClient` default export
- Removed stale frontend tsconfig comments and unused eslint tsconfig

## Reason

This keeps the frontend cleaner by removing unused exports, stale config, and unnecessary indirection.

## Impact

No breaking changes expected. Frontend typecheck, lint, and build pass.

## Checklist

- [x] Code builds
- [x] Self-reviewed
- [x] No unrelated changes