### PR TITLE
fix mobile responsive navigation

### DIFF
--- a/frontend/src/components/sidebar/Sidebar.module.css
+++ b/frontend/src/components/sidebar/Sidebar.module.css
@@ -1,18 +1,21 @@
 .sidebar {
-  height: 100%;
-  padding: 28px 18px 22px;
+  height: auto;
+  min-height: 0;
+  padding: 12px;
+  border-radius: 0 0 22px 22px;
   background: linear-gradient(180deg, #4d5ee8 0%, #474ccf 34%, #4336b1 100%);
   color: #fff;
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: 12px;
+  box-shadow: 0 14px 34px rgba(31, 37, 105, 0.22);
 }
 
 .brandRow {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 2px 6px 10px;
+  padding: 2px 4px;
 }
 
 .brandIcon {
@@ -39,15 +42,16 @@
 
 .menu {
   display: grid;
-  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
 }
 
 .navItem {
   display: flex;
   align-items: center;
-  gap: 12px;
-  min-height: 74px;
-  padding: 14px 15px;
+  gap: 10px;
+  min-height: 56px;
+  padding: 10px;
   border-radius: 14px;
   text-decoration: none;
   color: rgba(255, 255, 255, 0.84);
@@ -67,8 +71,8 @@
 }
 
 .itemIcon {
-  width: 40px;
-  height: 40px;
+  width: 36px;
+  height: 36px;
   flex: 0 0 auto;
   border-radius: 12px;
   display: grid;
@@ -94,22 +98,23 @@
 }
 
 .itemTitle {
-  font-size: 0.98rem;
+  font-size: 0.92rem;
   font-weight: 800;
   line-height: 1.1;
 }
 
 .itemSubtitle {
+  display: none;
   font-size: 0.86rem;
   line-height: 1.2;
   color: rgba(237, 240, 255, 0.74);
 }
 
 .footerCard {
+  display: none;
   margin-top: auto;
   border-radius: 18px;
   padding: 18px 16px 18px 14px;
-  display: flex;
   align-items: flex-start;
   gap: 14px;
   background: linear-gradient(
@@ -187,14 +192,46 @@
   line-height: 1.45;
 }
 
-@media (max-width: 920px) {
+@media (min-width: 480px) {
+  .itemSubtitle {
+    display: block;
+  }
+}
+
+@media (min-width: 960px) {
   .sidebar {
-    height: auto;
-    min-height: 0;
-    border-radius: 0 0 24px 24px;
+    height: 100%;
+    padding: 28px 18px 22px;
+    border-radius: 0;
+    gap: 22px;
+    box-shadow: none;
+  }
+
+  .brandRow {
+    padding: 2px 6px 10px;
+  }
+
+  .menu {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+
+  .navItem {
+    gap: 12px;
+    min-height: 74px;
+    padding: 14px 15px;
+  }
+
+  .itemIcon {
+    width: 40px;
+    height: 40px;
+  }
+
+  .itemTitle {
+    font-size: 0.98rem;
   }
 
   .footerCard {
-    display: none;
+    display: flex;
   }
 }

--- a/frontend/src/components/survey/RatingRow.module.css
+++ b/frontend/src/components/survey/RatingRow.module.css
@@ -35,6 +35,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 44px;
+  height: 44px;
 }
 
 .radioInput {
@@ -60,6 +62,10 @@
   transition: all 160ms ease;
 }
 
+.mobileOptionLabel {
+  display: none;
+}
+
 .radioInput:hover ~ .optionButton {
   border-color: rgba(91, 92, 226, 0.3);
   box-shadow: 0 2px 8px rgba(91, 92, 226, 0.1);
@@ -74,6 +80,47 @@
 .radioInput:focus-visible ~ .optionButton {
   outline: 2px solid #5b5ce2;
   outline-offset: 2px;
+}
+
+@media (max-width: 719px) {
+  .ratingTableRow {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 8px;
+    padding: 14px;
+    border: 1px solid #e4e8f4;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.04);
+  }
+
+  .statementCell {
+    grid-column: 1 / -1;
+    padding: 0 0 4px;
+    font-size: 0.9rem;
+  }
+
+  .ratingCell {
+    padding: 0;
+  }
+
+  .ratingOption {
+    width: 100%;
+    min-height: 52px;
+    display: grid;
+    gap: 5px;
+    justify-items: center;
+    align-content: center;
+    border-radius: 14px;
+  }
+
+  .mobileOptionLabel {
+    display: block;
+    color: #5f6882;
+    font-size: 0.72rem;
+    font-weight: 800;
+    line-height: 1;
+  }
 }
 
 @media (min-width: 1024px) {

--- a/frontend/src/components/survey/RatingRow.tsx
+++ b/frontend/src/components/survey/RatingRow.tsx
@@ -40,6 +40,7 @@ function RatingRow({ label, fieldName, register, error }: RatingRowProps) {
                 aria-describedby={error ? errorId : undefined}
               />
               <span className={styles.optionButton} aria-hidden="true" />
+              <span className={styles.mobileOptionLabel}>{option.value}</span>
             </label>
           </td>
         );

--- a/frontend/src/components/survey/SurveyForm.module.css
+++ b/frontend/src/components/survey/SurveyForm.module.css
@@ -155,18 +155,17 @@
 }
 
 .tableWrap {
-  overflow-x: auto;
+  overflow: visible;
   border-radius: 18px;
   border: 1px solid #e4e8f4;
   background: #fff;
   box-shadow: 0 8px 18px rgba(15, 23, 42, 0.04);
-  -webkit-overflow-scrolling: touch;
 }
 
 .ratingTable {
   width: 100%;
-  min-width: 650px;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 .ratingTable thead th {
@@ -197,7 +196,7 @@
 }
 
 .headCell {
-  min-width: 72px;
+  width: 13.6%;
 }
 
 .headCell span,
@@ -281,6 +280,41 @@
     min-width: 260px;
     min-height: 56px;
     padding: 0 28px;
+  }
+}
+
+@media (max-width: 719px) {
+  .tableWrap {
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .ratingTable,
+  .ratingTable thead,
+  .ratingTable tbody,
+  .ratingTable td {
+    display: block;
+    width: 100%;
+  }
+
+  .ratingTable thead {
+    display: none;
+  }
+
+  .ratingTable tbody {
+    display: grid;
+    gap: 12px;
+  }
+
+  .ratingTable tbody td {
+    padding: 0;
+    border-bottom: 0;
+  }
+
+  .headLabel,
+  .headCell {
+    width: auto;
   }
 }
 

--- a/frontend/src/layouts/AppLayout.module.css
+++ b/frontend/src/layouts/AppLayout.module.css
@@ -18,7 +18,10 @@
 }
 
 .sidebar {
-  display: none;
+  display: block;
+  position: sticky;
+  top: 0;
+  z-index: 20;
 }
 
 .contentArea {
@@ -78,48 +81,6 @@
   color: #6d7388;
   font-size: 0.95rem;
   line-height: 1.4;
-}
-
-.headerMeta {
-  display: grid;
-  gap: 12px;
-}
-
-.progressBlock {
-  display: grid;
-  gap: 8px;
-  min-width: 0;
-}
-
-.progressLabelRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.progressLabel {
-  color: #3f4760;
-  font-size: 0.92rem;
-  font-weight: 800;
-  letter-spacing: -0.01em;
-}
-
-.progressTrack {
-  position: relative;
-  height: 7px;
-  border-radius: 999px;
-  overflow: hidden;
-  background: rgba(213, 218, 238, 0.95);
-}
-
-.progressFill {
-  display: block;
-  width: 34%;
-  height: 100%;
-  border-radius: inherit;
-  background: linear-gradient(90deg, #5f60e0 0%, #4c5ad9 100%);
-  box-shadow: 0 8px 18px rgba(89, 95, 226, 0.28);
 }
 
 .saveButton {
@@ -357,11 +318,10 @@
   }
 
   .sidebar {
-    display: block;
     position: sticky;
     top: 0;
     height: 100dvh;
-    overflow: hidden;
+    overflow-y: auto;
   }
 
   .contentArea {

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -30,18 +30,6 @@ function AppHeader() {
           </p>
         </div>
       </div>
-
-      <div className={styles.headerMeta}>
-        <div className={styles.progressBlock} aria-label="Survey progress">
-          <div className={styles.progressLabelRow}>
-            <span className={styles.progressLabel}>Step 1 of 3</span>
-          </div>
-
-          <div className={styles.progressTrack} aria-hidden="true">
-            <span className={styles.progressFill} />
-          </div>
-        </div>
-      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Summary

Fixes mobile UX issues in the frontend layout:

## Changes

- makes the sidebar navigation visible on mobile as a compact top navigation
- ensures the Results navigation icon/link is available on small screens
- removes the mobile horizontal scroll caused by the survey rating table
- converts mobile rating rows into stacked responsive cards
- allows the desktop sidebar to scroll vertically instead of clipping content
- removes survey progress markup from the shared header

## Reason

The frontend had several responsive usability issues affecting navigation and accessibility on smaller screens. Users could not reliably access navigation actions such as Results on mobile, the survey table caused horizontal overflow, and desktop sidebar content could clip on smaller viewport heights.

## Impact

improves mobile navigation and survey interaction usability
removes layout overflow issues on smaller screens

## Checklist

- [ ] Code builds
- [ ] Self-reviewed
- [ ] No unrelated changes
